### PR TITLE
FIX issue#25: adding focus programmatically

### DIFF
--- a/src/app/events/event.service.spec.ts
+++ b/src/app/events/event.service.spec.ts
@@ -52,18 +52,18 @@ describe('EventService', () => {
   }));
 
   it('should be created', () => {
-    const service: EventService = TestBed.get(EventService);
+    const service: EventService = TestBed.inject(EventService);
     expect(service).toBeTruthy();
   });
 
   it('should return the observable from the API', () => {
-    const service: EventService = TestBed.get(EventService);
+    const service: EventService = TestBed.inject(EventService);
     expect(service.events$ instanceof Observable).toBeTruthy();
   });
 
   it('should pass the data coming from the API', fakeAsync(() => {
     let result: Array<SportsEvent> | undefined;
-    const service: EventService = TestBed.get(EventService);
+    const service: EventService = TestBed.inject(EventService);
     service.events$.subscribe(
       (value) => { result = value; }
     );
@@ -79,11 +79,11 @@ describe('EventService', () => {
 
     beforeEach(() => {
       // GIVEN
-      service = TestBed.get(EventService);
+      service = TestBed.inject(EventService);
     });
 
     it('should post data to the API', () => {
-      const postSpy = spyOn(TestBed.get(SbHttpService), 'post');
+      const postSpy = spyOn(TestBed.inject(SbHttpService), 'post');
       // WHEN
       service.addEvent(POST_DATA);
       // THEN
@@ -110,11 +110,11 @@ describe('EventService', () => {
 
     beforeEach(() => {
       // GIVEN
-      service = TestBed.get(EventService);
+      service = TestBed.inject(EventService);
     });
 
     it('should post data to the API', () => {
-      const deleteSpy = spyOn(TestBed.get(SbHttpService), 'delete');
+      const deleteSpy = spyOn(TestBed.inject(SbHttpService), 'delete');
       // WHEN
       service.deleteEvent(DELETE_DATA);
       // THEN

--- a/src/app/login-form/login-form.component.spec.ts
+++ b/src/app/login-form/login-form.component.spec.ts
@@ -50,8 +50,8 @@ describe('LoginFormComponent', () => {
   }));
 
   beforeEach(() => {
-    router = TestBed.get(Router);
-    location = TestBed.get(Location);
+    router = TestBed.inject(Router);
+    location = TestBed.inject(Location);
     fixture = TestBed.createComponent(LoginFormComponent);
     component = fixture.componentInstance;
     router.initialNavigation();
@@ -71,7 +71,7 @@ describe('LoginFormComponent', () => {
 
   xit('should redirect to returnUrl on successful authentication', fakeAsync(() => {
     const PATH = '/login?redirectTo=%2Fblah';
-    activatedRoute = TestBed.get(ActivatedRoute);
+    activatedRoute = TestBed.inject(ActivatedRoute);
     router.navigateByUrl(PATH);
     tick();
     expect(location.path()).toBe(PATH);

--- a/src/app/logout/logout.component.spec.ts
+++ b/src/app/logout/logout.component.spec.ts
@@ -44,7 +44,7 @@ describe('LogoutComponent', () => {
   });
 
   it('should log out', () => {
-    const authServiceLogoutSpy = spyOn(TestBed.get(AuthService), 'logout');
+    const authServiceLogoutSpy = spyOn(TestBed.inject(AuthService), 'logout');
 
     expect(authServiceLogoutSpy).not.toHaveBeenCalled();
     fixture.detectChanges();
@@ -53,7 +53,7 @@ describe('LogoutComponent', () => {
 
   it('should navigate to home page', () => {
     // test is implementation dependent, component could call navigateByUrl as well
-    const routerNavigateSpy = spyOn(TestBed.get(Router), 'navigate');
+    const routerNavigateSpy = spyOn(TestBed.inject(Router), 'navigate');
 
     expect(routerNavigateSpy).not.toHaveBeenCalled();
     fixture.detectChanges();

--- a/src/app/services/auth.service.spec.ts
+++ b/src/app/services/auth.service.spec.ts
@@ -30,8 +30,8 @@ describe('AuthService', () => {
         { provide: SbPersistentStorageService, useValue: sbPersistentStorageStubService },
       ]
     });
-    service = TestBed.get(AuthService);
-    const persistentSaveSpy = spyOn(TestBed.get(SbPersistentStorageService), 'save');
+    service = TestBed.inject(AuthService);
+    const persistentSaveSpy = spyOn(TestBed.inject(SbPersistentStorageService), 'save');
     persistentSaveSpy.calls.reset();
   });
 
@@ -46,7 +46,7 @@ describe('AuthService', () => {
     let httpError: HttpErrorResponse | null;
 
     beforeEach(() => {
-      httpMock = TestBed.get(HttpTestingController);
+      httpMock = TestBed.inject(HttpTestingController);
 
       httpResponse = null;
       httpError = null;
@@ -67,7 +67,7 @@ describe('AuthService', () => {
 
     it('should make successful HTTP call to the API', () => {
       const mockRequest = httpMock.expectOne(API_ENDPOINT);
-      const persistentSaveSpy = TestBed.get(SbPersistentStorageService).save;
+      const persistentSaveSpy = TestBed.inject(SbPersistentStorageService).save;
       const token_key = 'token';
 
       expect(mockRequest.cancelled).toBeFalsy();
@@ -103,7 +103,7 @@ describe('AuthService', () => {
 
     it('should return set token from persistent storage if no token yet', () => {
       service.token = '';
-      const retrieveSpy = spyOn(TestBed.get(SbPersistentStorageService), 'retrieve');
+      const retrieveSpy = spyOn(TestBed.inject(SbPersistentStorageService), 'retrieve');
       retrieveSpy.withArgs('token', true).and.returnValue('SESSION_TOKEN');
       retrieveSpy.withArgs('token', false).and.returnValue('LOCAL_TOKEN');
       retrieveSpy.withArgs('token').and.returnValue('LOCAL_TOKEN2');
@@ -120,7 +120,7 @@ describe('AuthService', () => {
 
   it('logout() method should clear token (from persistent storage as well)', () => {
     service.token = TOKEN;
-    const persistentSaveSpy = TestBed.get(SbPersistentStorageService).save;
+    const persistentSaveSpy = TestBed.inject(SbPersistentStorageService).save;
     const token_key = 'token';
 
     service.logout();

--- a/src/app/services/sb-http.service.spec.ts
+++ b/src/app/services/sb-http.service.spec.ts
@@ -61,8 +61,8 @@ describe('SbHttpService', () => {
         { provide: AuthService, useValue: AuthStubService }
       ]
     });
-    service = TestBed.get(SbHttpService);
-    httpMock = TestBed.get(HttpTestingController);
+    service = TestBed.inject(SbHttpService);
+    httpMock = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/app/services/sb-persistent-storage.service.spec.ts
+++ b/src/app/services/sb-persistent-storage.service.spec.ts
@@ -6,7 +6,7 @@ describe('SbPersistentStorageService', () => {
   beforeEach(() => TestBed.configureTestingModule({}));
 
   it('should be created', () => {
-    const service: SbPersistentStorageService = TestBed.get(SbPersistentStorageService);
+    const service: SbPersistentStorageService = TestBed.inject(SbPersistentStorageService);
     expect(service).toBeTruthy();
   });
 });

--- a/src/app/stadiums/add-stadium/add-stadium.component.html
+++ b/src/app/stadiums/add-stadium/add-stadium.component.html
@@ -5,6 +5,7 @@
     name="name"
     formControlName="name"
     placeholder="Stadium Name"
+    #stadiumName
     >
     <mat-error *ngIf="addForm.controls.name.invalid">Name cannot be empty!</mat-error>
   </mat-form-field>

--- a/src/app/stadiums/add-stadium/add-stadium.component.spec.ts
+++ b/src/app/stadiums/add-stadium/add-stadium.component.spec.ts
@@ -46,7 +46,7 @@ describe('AddStadiumComponent', () => {
     component = fixture.componentInstance;
     fixture.detectChanges();
 
-    service = TestBed.get(StadiumService);
+    service = TestBed.inject(StadiumService);
     formElement = fixture.debugElement.query(By.css('form'));
     inputElement = fixture.debugElement.query(By.css('input'));
   });

--- a/src/app/stadiums/add-stadium/add-stadium.component.spec.ts
+++ b/src/app/stadiums/add-stadium/add-stadium.component.spec.ts
@@ -87,9 +87,9 @@ describe('AddStadiumComponent', () => {
 
   it('should have the input field focused', async(() => {
     fixture.whenStable().then(() => {
-      const focusElement = fixture.debugElement.query(By.css(":focus"));
+      const focusElement = fixture.debugElement.query(By.css(':focus'));
       expect(focusElement).toBe(inputElement);
-    })
+    });
   }));
 
   function fillForm(value) {

--- a/src/app/stadiums/add-stadium/add-stadium.component.spec.ts
+++ b/src/app/stadiums/add-stadium/add-stadium.component.spec.ts
@@ -85,6 +85,13 @@ describe('AddStadiumComponent', () => {
     expect(initMethod).toHaveBeenCalled();
   });
 
+  it('should have the input field focused', async(() => {
+    fixture.whenStable().then(() => {
+      const focusElement = fixture.debugElement.query(By.css(":focus"));
+      expect(focusElement).toBe(inputElement);
+    })
+  }));
+
   function fillForm(value) {
     inputElement.nativeElement.value = value;
     // does not work: inputElement.triggerEventHandler('input', null);

--- a/src/app/stadiums/add-stadium/add-stadium.component.ts
+++ b/src/app/stadiums/add-stadium/add-stadium.component.ts
@@ -1,7 +1,8 @@
-import { Component, OnInit, Output, EventEmitter } from '@angular/core';
+import { Component, OnInit, Output, EventEmitter, ViewChild, ElementRef } from '@angular/core';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { HttpErrorResponse } from '@angular/common/http';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatInput } from '@angular/material/input';
 
 import { StadiumService } from '../stadium.service';
 
@@ -12,6 +13,7 @@ import { StadiumService } from '../stadium.service';
 })
 export class AddStadiumComponent implements OnInit {
 
+  @ViewChild('stadiumName', { static: true }) input: ElementRef<MatInput>;
   addForm: FormGroup;
   showAdd: boolean;
   @Output() close = new EventEmitter();
@@ -26,6 +28,7 @@ export class AddStadiumComponent implements OnInit {
     this.addForm = new FormGroup({
       name: new FormControl('', [Validators.required]),
     });
+    this.input.nativeElement.focus();
   }
 
   onSubmit() {

--- a/src/app/stadiums/stadium.service.spec.ts
+++ b/src/app/stadiums/stadium.service.spec.ts
@@ -23,7 +23,7 @@ describe('StadiumService', () => {
   }));
 
   it('should be created', () => {
-    const service: StadiumService = TestBed.get(StadiumService);
+    const service: StadiumService = TestBed.inject(StadiumService);
     expect(service).toBeTruthy();
   });
 });


### PR DESCRIPTION
With angular 8's static viewChild, it was possible to do this without a setTimeout trick.
When using ngAfterViewInit, you can't modify the DOM and focus... (or you get an "Expression has changed after it was checked" error)